### PR TITLE
Reduced focal loss implementation is incorrect for binary case

### DIFF
--- a/pytorch_toolbelt/losses/functional.py
+++ b/pytorch_toolbelt/losses/functional.py
@@ -70,7 +70,7 @@ def focal_loss_with_logits(
     if reduced_threshold is None:
         focal_term = (1.0 - pt).pow(gamma)
     else:
-        focal_term = ((1.0 - pt) / (1 - reduced_threshold)).pow(gamma) #the focal term continuity breaks when reduced_threshold < 0.5. At pt == reduced_threshold, focal term should be 1 from both sides.
+        focal_term = ((1.0 - pt) / (1 - reduced_threshold)).pow(gamma) #the focal term continuity breaks when reduced_threshold not equal to 0.5. At pt equal to reduced_threshold, the value of piecewise function of focal term should be 1 from both sides .
         focal_term = torch.masked_fill(focal_term, pt < reduced_threshold, 1)
 
     loss = focal_term * ce_loss

--- a/pytorch_toolbelt/losses/functional.py
+++ b/pytorch_toolbelt/losses/functional.py
@@ -70,7 +70,7 @@ def focal_loss_with_logits(
     if reduced_threshold is None:
         focal_term = (1.0 - pt).pow(gamma)
     else:
-        focal_term = ((1.0 - pt) / reduced_threshold).pow(gamma)
+        focal_term = ((1.0 - pt) / (1 - reduced_threshold)).pow(gamma) #the focal term continuity breaks when reduced_threshold < 0.5. At pt == reduced_threshold, focal term should be 1 from both sides.
         focal_term = torch.masked_fill(focal_term, pt < reduced_threshold, 1)
 
     loss = focal_term * ce_loss


### PR DESCRIPTION
The current implementation is same as the one given in original [paper ](https://arxiv.org/abs/1903.01347). Although, it doesn't work as intended when value of reduced threshold is not 0.5. As per the paper, the focal term should be 1 when pt is less than reduced threshold and then exponentially decrease from 1 to 0 as pt goes from reduced threshold to 1. By this logic, the value of focal term should be 1 at pt equal to reduced threshold from both sides of the curve. From RHS the value is given as (1-pt/thresh) to power gamma multiplied by log pt. This will only be 1 at pt=thresh, when thresh=0.5, otherwise not. 

So the correct formula focal term for pt>thresh should be  ((1-pt)/(1-thresh) to the power gamma multiplied by log pt.

The corrected implementation goes hand in hand with the one done for  softmax_focal_loss_with_logits which works as intended in the paper. 