### PR TITLE
change the use of np.ndarray to np.array

### DIFF
--- a/pytorch_toolbelt/utils/torch_utils.py
+++ b/pytorch_toolbelt/utils/torch_utils.py
@@ -179,7 +179,7 @@ def to_tensor(x, dtype=None) -> torch.Tensor:
             x = x.type(dtype)
         return x
     if isinstance(x, (list, tuple)):
-        x = np.ndarray(x)
+        x = np.array(x)
         x = torch.from_numpy(x)
         if dtype is not None:
             x = x.type(dtype)


### PR DESCRIPTION
The current line "np.ndarray(x)" will create a ndarray with the dimension of x, if x is a list of integers, or error out if not.

We should use np.array(x) to create a ndarray which has the same values of x.